### PR TITLE
Refactor SolidMediaPlate to Implementation-based inventory modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ SBOLInventory is a Python package for representing laboratory inventory objects 
 
 The package wraps the core ideas in the initial prototype into a reusable library:
 
-- `InventoryImplementation` extends SBOL `Implementation`
-- `StorageCollection` extends SBOL `Collection`
+- `InventoryImplementation` extends SBOL `Implementation` for **all physical inventory objects** (`ExtractedPlasmid`, `BacterialStock`, and `SolidMediaPlate`)
+- `StorageCollection` extends SBOL `Collection` for storage hierarchy nodes only (`FridgeMinus80C`, `FridgeMinus20C`, `Fridge4C`, `Shelf`, `Box`, `Slot`)
 - factory functions create typed inventory objects and storage nodes
 - containment helpers connect freezers, shelves, boxes, slots, and stored items
 - validation helpers enforce placement rules
@@ -23,10 +23,12 @@ Those can be built later on top of this package.
 
 ## Domain model
 
-### Inventory implementations
+### Inventory implementations (SBOL `Implementation`)
 - `ExtractedPlasmid`
 - `BacterialStock`
 - `SolidMediaPlate`
+
+`SolidMediaPlate` is an inventory item, not a storage node. It may point to a design via `built`, and it is placed into `Slot` collections like other inventory implementations.
 
 ### Storage hierarchy
 - `FridgeMinus80C`

--- a/agent.md
+++ b/agent.md
@@ -25,8 +25,8 @@ When code and docs diverge, update the docs in the same change.
 ## Current package intent
 The initial implementation should preserve the core behavior of the prototype:
 
-- custom `InventoryImplementation`
-- custom `StorageCollection`
+- custom `InventoryImplementation` (including `SolidMediaPlate`)
+- custom `StorageCollection` (storage hierarchy only)
 - controlled vocabulary constants
 - storage factories
 - implementation factories

--- a/architechture.md
+++ b/architechture.md
@@ -25,8 +25,8 @@ This module is the single source of truth for vocabulary constants.
 ### `schema.py`
 Contains the extension-aware object definitions:
 
-- `InventoryImplementation`
-- `StorageCollection`
+- `InventoryImplementation` for physical tracked items (`ExtractedPlasmid`, `BacterialStock`, `SolidMediaPlate`)
+- `StorageCollection` for storage hierarchy nodes (`FridgeMinus80C`, `FridgeMinus20C`, `Fridge4C`, `Shelf`, `Box`, `Slot`)
 
 Responsibilities:
 - define extension properties
@@ -86,6 +86,8 @@ The storage system is naturally hierarchical and grouping-oriented. `Collection`
 - slots
 
 That keeps the storage layout explicit without inventing a second containment mechanism.
+
+`SolidMediaPlate` is intentionally not modeled as a collection/container root; it is a physical inventory implementation that is placed into slot collections.
 
 ### Why keep validation separate
 Constructors should create objects.

--- a/notebooks/sbol_inventory_examples.ipynb
+++ b/notebooks/sbol_inventory_examples.ipynb
@@ -1,222 +1,221 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# SBOLInventory examples\n",
-        "\n",
-        "This notebook demonstrates how to use **SBOLInventory** to build a storage hierarchy, create inventory implementations, place them into slots, validate placements, and assemble an SBOL document."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import sbol2 as sbol\n",
-        "\n",
-        "from sbol_inventory import (\n",
-        "    make_document,\n",
-        "    add_all,\n",
-        "    make_fridge_minus80,\n",
-        "    make_fridge_minus20,\n",
-        "    make_fridge_4c,\n",
-        "    make_shelf,\n",
-        "    make_box,\n",
-        "    make_slot,\n",
-        "    make_bacterial_stock,\n",
-        "    make_extracted_plasmid,\n",
-        "    make_solid_media_plate,\n",
-        "    add_child,\n",
-        "    place_item,\n",
-        "    validate_item,\n",
-        "    validate_placement,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 1: create a -80 \u00b0C hierarchy and place a bacterial stock"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "doc = make_document()\n",
-        "\n",
-        "freezer = make_fridge_minus80(\"https://example.org/storage/-80\")\n",
-        "shelf = make_shelf(\"https://example.org/storage/-80/shelf2\", label=\"Shelf 2\")\n",
-        "box = make_box(\"https://example.org/storage/-80/shelf2/box4\", label=\"Box 4\")\n",
-        "slot = make_slot(\"https://example.org/storage/-80/shelf2/box4/A4\", label=\"A4\")\n",
-        "\n",
-        "stock = make_bacterial_stock(\n",
-        "    uri=\"https://example.org/implementation/bstock_001\",\n",
-        "    strain_md_uri=\"https://example.org/designs/strain_md_001\",\n",
-        ")\n",
-        "\n",
-        "add_all(doc, [freezer, shelf, box, slot, stock])\n",
-        "add_child(freezer, shelf)\n",
-        "add_child(shelf, box)\n",
-        "add_child(box, slot)\n",
-        "place_item(slot, stock)\n",
-        "\n",
-        "validate_item(stock)\n",
-        "validate_placement(stock, slot)\n",
-        "\n",
-        "print(\"Stored at:\", stock.stored_at)\n",
-        "print(\"Slot members:\", list(slot.members))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 2: create a -20 \u00b0C hierarchy and place an extracted plasmid"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "freezer20 = make_fridge_minus20(\"https://example.org/storage/-20\")\n",
-        "shelf20 = make_shelf(\"https://example.org/storage/-20/shelf1\", label=\"Shelf 1\")\n",
-        "box20 = make_box(\"https://example.org/storage/-20/shelf1/box2\", label=\"Box 2\")\n",
-        "slot20 = make_slot(\n",
-        "    \"https://example.org/storage/-20/shelf1/box2/B3\",\n",
-        "    label=\"B3\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#ExtractedPlasmid\"],\n",
-        ")\n",
-        "\n",
-        "plasmid = make_extracted_plasmid(\n",
-        "    uri=\"https://example.org/implementation/plasmid_001\",\n",
-        "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_001\",\n",
-        ")\n",
-        "\n",
-        "for obj in [freezer20, shelf20, box20, slot20, plasmid]:\n",
-        "    doc.add(obj)\n",
-        "\n",
-        "add_child(freezer20, shelf20)\n",
-        "add_child(shelf20, box20)\n",
-        "add_child(box20, slot20)\n",
-        "place_item(slot20, plasmid)\n",
-        "\n",
-        "validate_item(plasmid)\n",
-        "validate_placement(plasmid, slot20)\n",
-        "\n",
-        "print(\"Plasmid stored at:\", plasmid.stored_at)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 3: create a 4 \u00b0C hierarchy and place a solid media plate"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "fridge4 = make_fridge_4c(\"https://example.org/storage/4c\")\n",
-        "shelf4 = make_shelf(\"https://example.org/storage/4c/shelf1\", label=\"Shelf 1\")\n",
-        "box4 = make_box(\"https://example.org/storage/4c/shelf1/rack1\", label=\"Rack 1\")\n",
-        "slot4 = make_slot(\n",
-        "    \"https://example.org/storage/4c/shelf1/rack1/P1\",\n",
-        "    label=\"P1\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#SolidMediaPlate\"],\n",
-        ")\n",
-        "\n",
-        "plate = make_solid_media_plate(\n",
-        "    uri=\"https://example.org/implementation/plate_001\",\n",
-        "    plate_md_uri=\"https://example.org/designs/plate_md_001\",\n",
-        ")\n",
-        "\n",
-        "for obj in [fridge4, shelf4, box4, slot4, plate]:\n",
-        "    doc.add(obj)\n",
-        "\n",
-        "add_child(fridge4, shelf4)\n",
-        "add_child(shelf4, box4)\n",
-        "add_child(box4, slot4)\n",
-        "place_item(slot4, plate)\n",
-        "\n",
-        "validate_item(plate)\n",
-        "validate_placement(plate, slot4)\n",
-        "\n",
-        "print(\"Plate stored at:\", plate.stored_at)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 4: show a validation failure"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "wrong_slot = make_slot(\n",
-        "    \"https://example.org/storage/-80/shelf9/box9/Z9\",\n",
-        "    label=\"Z9\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#BacterialStock\"],\n",
-        ")\n",
-        "\n",
-        "wrong_item = make_extracted_plasmid(\n",
-        "    uri=\"https://example.org/implementation/plasmid_bad\",\n",
-        "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_bad\",\n",
-        ")\n",
-        "\n",
-        "try:\n",
-        "    validate_placement(wrong_item, wrong_slot)\n",
-        "except ValueError as e:\n",
-        "    print(\"Validation error:\", e)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 5: serialize the document"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Uncomment to write RDF/XML once sbol2 is installed and configured:\n",
-        "# from sbol_inventory import write_rdfxml\n",
-        "# write_rdfxml(doc, \"inventory_example.xml\")\n",
-        "# print(\"Wrote inventory_example.xml\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SBOLInventory examples\n",
+    "\n",
+    "This notebook demonstrates how to use **SBOLInventory** to build a storage hierarchy, create inventory implementations, place them into slots, validate placements, and assemble an SBOL document."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbol_inventory import (\n",
+    "    make_document,\n",
+    "    add_all,\n",
+    "    make_fridge_minus80,\n",
+    "    make_fridge_minus20,\n",
+    "    make_fridge_4c,\n",
+    "    make_shelf,\n",
+    "    make_box,\n",
+    "    make_slot,\n",
+    "    make_bacterial_stock,\n",
+    "    make_extracted_plasmid,\n",
+    "    make_solid_media_plate,\n",
+    "    add_child,\n",
+    "    place_item,\n",
+    "    validate_item,\n",
+    "    validate_placement,\n",
+    "    SOLID_MEDIA_PLATE,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: create a -80 \u00b0C hierarchy and place a bacterial stock"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = make_document()\n",
+    "\n",
+    "freezer = make_fridge_minus80(\"https://example.org/storage/-80\")\n",
+    "shelf = make_shelf(\"https://example.org/storage/-80/shelf2\", label=\"Shelf 2\")\n",
+    "box = make_box(\"https://example.org/storage/-80/shelf2/box4\", label=\"Box 4\")\n",
+    "slot = make_slot(\"https://example.org/storage/-80/shelf2/box4/A4\", label=\"A4\")\n",
+    "\n",
+    "stock = make_bacterial_stock(\n",
+    "    uri=\"https://example.org/implementation/bstock_001\",\n",
+    "    strain_md_uri=\"https://example.org/designs/strain_md_001\",\n",
+    ")\n",
+    "\n",
+    "add_all(doc, [freezer, shelf, box, slot, stock])\n",
+    "add_child(freezer, shelf)\n",
+    "add_child(shelf, box)\n",
+    "add_child(box, slot)\n",
+    "place_item(slot, stock)\n",
+    "\n",
+    "validate_item(stock)\n",
+    "validate_placement(stock, slot)\n",
+    "\n",
+    "print(\"Stored at:\", stock.stored_at)\n",
+    "print(\"Slot members:\", list(slot.members))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: create a -20 \u00b0C hierarchy and place an extracted plasmid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freezer20 = make_fridge_minus20(\"https://example.org/storage/-20\")\n",
+    "shelf20 = make_shelf(\"https://example.org/storage/-20/shelf1\", label=\"Shelf 1\")\n",
+    "box20 = make_box(\"https://example.org/storage/-20/shelf1/box2\", label=\"Box 2\")\n",
+    "slot20 = make_slot(\n",
+    "    \"https://example.org/storage/-20/shelf1/box2/B3\",\n",
+    "    label=\"B3\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#ExtractedPlasmid\"],\n",
+    ")\n",
+    "\n",
+    "plasmid = make_extracted_plasmid(\n",
+    "    uri=\"https://example.org/implementation/plasmid_001\",\n",
+    "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_001\",\n",
+    ")\n",
+    "\n",
+    "for obj in [freezer20, shelf20, box20, slot20, plasmid]:\n",
+    "    doc.add(obj)\n",
+    "\n",
+    "add_child(freezer20, shelf20)\n",
+    "add_child(shelf20, box20)\n",
+    "add_child(box20, slot20)\n",
+    "place_item(slot20, plasmid)\n",
+    "\n",
+    "validate_item(plasmid)\n",
+    "validate_placement(plasmid, slot20)\n",
+    "\n",
+    "print(\"Plasmid stored at:\", plasmid.stored_at)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: create a 4 \u00b0C hierarchy and place a solid media plate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fridge4 = make_fridge_4c(\"https://example.org/storage/4c\")\n",
+    "shelf4 = make_shelf(\"https://example.org/storage/4c/shelf1\", label=\"Shelf 1\")\n",
+    "box4 = make_box(\"https://example.org/storage/4c/shelf1/rack1\", label=\"Rack 1\")\n",
+    "slot4 = make_slot(\n",
+    "    \"https://example.org/storage/4c/shelf1/rack1/P1\",\n",
+    "    label=\"P1\",\n",
+    "    allowed_item_kinds=[SOLID_MEDIA_PLATE],\n",
+    ")\n",
+    "\n",
+    "plate = make_solid_media_plate(\n",
+    "    uri=\"https://example.org/implementation/plate_001\",\n",
+    "    plate_md_uri=\"https://example.org/designs/plate_md_001\",\n",
+    ")\n",
+    "\n",
+    "for obj in [fridge4, shelf4, box4, slot4, plate]:\n",
+    "    doc.add(obj)\n",
+    "\n",
+    "add_child(fridge4, shelf4)\n",
+    "add_child(shelf4, box4)\n",
+    "add_child(box4, slot4)\n",
+    "place_item(slot4, plate)\n",
+    "\n",
+    "validate_item(plate)\n",
+    "validate_placement(plate, slot4)\n",
+    "\n",
+    "print(\"Plate stored at:\", plate.stored_at)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: show a validation failure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrong_slot = make_slot(\n",
+    "    \"https://example.org/storage/-80/shelf9/box9/Z9\",\n",
+    "    label=\"Z9\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#BacterialStock\"],\n",
+    ")\n",
+    "\n",
+    "wrong_item = make_extracted_plasmid(\n",
+    "    uri=\"https://example.org/implementation/plasmid_bad\",\n",
+    "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_bad\",\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    validate_placement(wrong_item, wrong_slot)\n",
+    "except ValueError as e:\n",
+    "    print(\"Validation error:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 5: serialize the document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to write RDF/XML once sbol2 is installed and configured:\n",
+    "# from sbol_inventory import write_rdfxml\n",
+    "# write_rdfxml(doc, \"inventory_example.xml\")\n",
+    "# print(\"Wrote inventory_example.xml\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/product.md
+++ b/product.md
@@ -27,7 +27,7 @@ Primary users:
 ## MVP
 The first release of SBOLInventory should support:
 
-- custom SBOL extension-aware classes for inventory objects and storage collections
+- custom SBOL extension-aware classes for inventory objects (`InventoryImplementation`) and storage collections (`StorageCollection`)
 - controlled vocabulary constants for item and storage kinds
 - factory functions for:
   - `ExtractedPlasmid`
@@ -59,7 +59,7 @@ This repository should not initially include:
 The package must support creation of typed SBOL implementations for:
 - extracted plasmid
 - bacterial stock
-- solid media plate
+- solid media plate (modeled as `InventoryImplementation`, not as storage)
 
 ### FR2: storage hierarchy creation
 The package must support creation of storage nodes for:

--- a/src/sbol_inventory/factories.py
+++ b/src/sbol_inventory/factories.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 from .namespaces import (
     EXTRACTED_PLASMID,
@@ -63,7 +63,7 @@ def make_slot(
     label: Optional[str] = None,
     row: Optional[str] = None,
     column: Optional[str] = None,
-    allowed_item_kinds=None,
+    allowed_item_kinds: Optional[Sequence[str]] = None,
 ) -> StorageCollection:
     x = StorageCollection(uri)
     x.storage_kind = SLOT
@@ -74,7 +74,7 @@ def make_slot(
     if column:
         x.column = column
     if allowed_item_kinds:
-        x.allowed_item_kinds = allowed_item_kinds
+        x.allowed_item_kinds = list(allowed_item_kinds)
     return x
 
 
@@ -118,7 +118,11 @@ def make_solid_media_plate(
     slot_uri: Optional[str] = None,
     design_uri: Optional[str] = None,
 ) -> InventoryImplementation:
-    """Create a solid media plate implementation."""
+    """Create a solid media plate inventory implementation.
+
+    Solid media plates are physical tracked items and intentionally modeled as
+    :class:`InventoryImplementation`, parallel to plasmids and bacterial stocks.
+    """
     x = InventoryImplementation(uri)
     x.inventory_kind = SOLID_MEDIA_PLATE
     x.built = plate_md_uri
@@ -129,14 +133,23 @@ def make_solid_media_plate(
     return x
 
 
+def _append_member(collection: StorageCollection, child_identity: str) -> None:
+    """Add a member identity for pySBOL2 list-like and set-like containers."""
+    members = collection.members
+    if hasattr(members, "add"):
+        members.add(child_identity)
+    else:
+        members.append(child_identity)
+
+
 def add_child(parent: StorageCollection, child) -> None:
     """Attach a storage node or inventory item to a parent collection."""
-    parent.members.add(child.identity)
+    _append_member(parent, child.identity)
     if isinstance(child, StorageCollection):
         child.parent_storage = parent.identity
 
 
 def place_item(slot: StorageCollection, item: InventoryImplementation) -> None:
     """Place an inventory item into a leaf slot."""
-    slot.members.add(item.identity)
+    _append_member(slot, item.identity)
     item.stored_at = slot.identity

--- a/src/sbol_inventory/validation.py
+++ b/src/sbol_inventory/validation.py
@@ -10,7 +10,12 @@ KNOWN_KINDS = {EXTRACTED_PLASMID, BACTERIAL_STOCK, SOLID_MEDIA_PLATE}
 
 
 def validate_item(item: InventoryImplementation) -> None:
-    """Validate an inventory object at the item level."""
+    """Validate an inventory object at the item level.
+
+    Every tracked physical inventory object (including solid media plates)
+    must be modeled as an :class:`InventoryImplementation` with a known
+    ``inventory_kind`` and a SBOL ``built`` reference.
+    """
     kind = str(item.inventory_kind)
 
     if kind not in KNOWN_KINDS:
@@ -21,8 +26,8 @@ def validate_item(item: InventoryImplementation) -> None:
 
 
 def validate_placement(item: InventoryImplementation, slot: StorageCollection) -> None:
-    """Validate whether an item is allowed to be placed in a slot."""
-    allowed = set(slot.allowed_item_kinds)
+    """Validate whether an implementation is allowed in a slot collection."""
+    allowed = {str(kind) for kind in slot.allowed_item_kinds}
     if allowed and str(item.inventory_kind) not in allowed:
         raise ValueError(
             f"{item.identity} of kind {item.inventory_kind} "

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,9 +2,13 @@ import pytest
 
 from sbol_inventory import (
     BACTERIAL_STOCK,
+    SOLID_MEDIA_PLATE,
+    InventoryImplementation,
     make_bacterial_stock,
     make_extracted_plasmid,
     make_slot,
+    make_solid_media_plate,
+    place_item,
     validate_item,
     validate_placement,
 )
@@ -41,3 +45,43 @@ def test_validate_placement_rejects_wrong_kind():
     )
     with pytest.raises(ValueError):
         validate_placement(item, slot)
+
+
+def test_make_solid_media_plate_returns_inventory_implementation():
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate_md1",
+    )
+
+    assert isinstance(plate, InventoryImplementation)
+    assert str(plate.inventory_kind) == SOLID_MEDIA_PLATE
+
+
+def test_solid_media_plate_can_be_placed_in_allowed_slot():
+    slot = make_slot(
+        "https://example.org/storage/4c/shelf1/box1/P1",
+        allowed_item_kinds=[SOLID_MEDIA_PLATE],
+    )
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate_md1",
+    )
+
+    validate_placement(plate, slot)
+    place_item(slot, plate)
+
+    assert str(plate.stored_at) == slot.identity
+
+
+def test_solid_media_plate_rejected_from_wrong_slot_type():
+    slot = make_slot(
+        "https://example.org/storage/-80/shelf1/box1/P1",
+        allowed_item_kinds=[BACTERIAL_STOCK],
+    )
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate_md1",
+    )
+
+    with pytest.raises(ValueError):
+        validate_placement(plate, slot)


### PR DESCRIPTION
### Motivation
- Ensure `SolidMediaPlate` is consistently represented as an SBOL `Implementation` (parallel to `ExtractedPlasmid` and `BacterialStock`) rather than treated as a Collection or storage node. 
- Keep the storage hierarchy (`Fridge*`, `Shelf`, `Box`, `Slot`) as `StorageCollection` objects while making all tracked physical items `InventoryImplementation`. 
- Align factories, validation, tests, notebook examples and docs so placement and semantics are unambiguous. 

### Description
- Made `make_solid_media_plate(...)` return an `InventoryImplementation` (kept `inventory_kind = SOLID_MEDIA_PLATE`) and added a clarifying docstring; kept its `built` and `stored_at` behavior parallel to other items. 
- Hardened `make_slot(...)` typing to accept `allowed_item_kinds: Optional[Sequence[str]]` and normalize assignment with `list(...)`. 
- Added a helper `_append_member(...)` to handle pySBOL2 member containers that may be list-like or set-like, and used it in `add_child(...)` and `place_item(...)` so membership additions work robustly. 
- Normalized placement validation by converting `slot.allowed_item_kinds` values to strings before comparison and clarified `validate_item(...)` docstring to assert that plates must be `InventoryImplementation` with a `built` reference. 
- Updated tests to prove `make_solid_media_plate(...)` returns an `InventoryImplementation`, that a plate can be placed into a `Slot` when allowed, and that placement is rejected for incompatible slot kinds. 
- Updated documentation and examples (`README.md`, `product.md`, `architechture.md`, `agent.md`, and `notebooks/sbol_inventory_examples.ipynb`) to state that storage nodes are Collection-based and all physical items (including plates) are Implementation-based. 
- Files modified: `src/sbol_inventory/factories.py`, `src/sbol_inventory/validation.py`, `tests/test_validation.py`, `README.md`, `product.md`, `architechture.md`, `agent.md`, and `notebooks/sbol_inventory_examples.ipynb`. 

### Testing
- Ran the linter with `ruff check .` and resolved the single notebook import issue so linting passes. 
- Ran unit tests with `PYTHONPATH=src pytest -q`, and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95faeafac8330ace7f47058ba0970)