### PR TITLE
Refactor SolidMediaPlate to be Implementation-based Inventory Item

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Those can be built later on top of this package.
 - `BacterialStock`
 - `SolidMediaPlate`
 
+All inventory items above are modeled as `InventoryImplementation` objects
+(SBOL `Implementation`), including `SolidMediaPlate`.
+
 ### Storage hierarchy
 - `FridgeMinus80C`
 - `FridgeMinus20C`
@@ -35,6 +38,9 @@ Those can be built later on top of this package.
 - `Shelf`
 - `Box`
 - `Slot`
+
+All storage nodes above are modeled as `StorageCollection` objects (SBOL
+`Collection`).
 
 ## Repository structure
 
@@ -109,6 +115,9 @@ place_item(slot, stock)
 
 validate_placement(stock, slot)
 ```
+
+`SolidMediaPlate` uses the same item workflow (`make_solid_media_plate`,
+`validate_placement`, `place_item`) and is **not** a storage node.
 
 ## Design principles
 

--- a/agent.md
+++ b/agent.md
@@ -33,6 +33,10 @@ The initial implementation should preserve the core behavior of the prototype:
 - containment helpers
 - placement validation
 
+Semantic requirement: `SolidMediaPlate` is a physical inventory item and must
+be modeled as `InventoryImplementation` (SBOL `Implementation`), not as a
+storage `Collection`.
+
 ## Repository rules
 
 ### 1. Keep scope tight

--- a/architechture.md
+++ b/architechture.md
@@ -77,6 +77,8 @@ Responsibilities:
 - `notes`
 - `freeze_date`
 
+This includes `ExtractedPlasmid`, `BacterialStock`, and `SolidMediaPlate`.
+
 ### Why extend `Collection`
 The storage system is naturally hierarchical and grouping-oriented. `Collection` is therefore a good fit for representing:
 
@@ -84,6 +86,9 @@ The storage system is naturally hierarchical and grouping-oriented. `Collection`
 - shelves
 - boxes
 - slots
+
+Only storage nodes are collections. A `SolidMediaPlate` is not a collection
+root and is treated the same way as other inventory implementations.
 
 That keeps the storage layout explicit without inventing a second containment mechanism.
 

--- a/notebooks/sbol_inventory_examples.ipynb
+++ b/notebooks/sbol_inventory_examples.ipynb
@@ -1,222 +1,225 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# SBOLInventory examples\n",
-        "\n",
-        "This notebook demonstrates how to use **SBOLInventory** to build a storage hierarchy, create inventory implementations, place them into slots, validate placements, and assemble an SBOL document."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import sbol2 as sbol\n",
-        "\n",
-        "from sbol_inventory import (\n",
-        "    make_document,\n",
-        "    add_all,\n",
-        "    make_fridge_minus80,\n",
-        "    make_fridge_minus20,\n",
-        "    make_fridge_4c,\n",
-        "    make_shelf,\n",
-        "    make_box,\n",
-        "    make_slot,\n",
-        "    make_bacterial_stock,\n",
-        "    make_extracted_plasmid,\n",
-        "    make_solid_media_plate,\n",
-        "    add_child,\n",
-        "    place_item,\n",
-        "    validate_item,\n",
-        "    validate_placement,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 1: create a -80 \u00b0C hierarchy and place a bacterial stock"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "doc = make_document()\n",
-        "\n",
-        "freezer = make_fridge_minus80(\"https://example.org/storage/-80\")\n",
-        "shelf = make_shelf(\"https://example.org/storage/-80/shelf2\", label=\"Shelf 2\")\n",
-        "box = make_box(\"https://example.org/storage/-80/shelf2/box4\", label=\"Box 4\")\n",
-        "slot = make_slot(\"https://example.org/storage/-80/shelf2/box4/A4\", label=\"A4\")\n",
-        "\n",
-        "stock = make_bacterial_stock(\n",
-        "    uri=\"https://example.org/implementation/bstock_001\",\n",
-        "    strain_md_uri=\"https://example.org/designs/strain_md_001\",\n",
-        ")\n",
-        "\n",
-        "add_all(doc, [freezer, shelf, box, slot, stock])\n",
-        "add_child(freezer, shelf)\n",
-        "add_child(shelf, box)\n",
-        "add_child(box, slot)\n",
-        "place_item(slot, stock)\n",
-        "\n",
-        "validate_item(stock)\n",
-        "validate_placement(stock, slot)\n",
-        "\n",
-        "print(\"Stored at:\", stock.stored_at)\n",
-        "print(\"Slot members:\", list(slot.members))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 2: create a -20 \u00b0C hierarchy and place an extracted plasmid"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "freezer20 = make_fridge_minus20(\"https://example.org/storage/-20\")\n",
-        "shelf20 = make_shelf(\"https://example.org/storage/-20/shelf1\", label=\"Shelf 1\")\n",
-        "box20 = make_box(\"https://example.org/storage/-20/shelf1/box2\", label=\"Box 2\")\n",
-        "slot20 = make_slot(\n",
-        "    \"https://example.org/storage/-20/shelf1/box2/B3\",\n",
-        "    label=\"B3\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#ExtractedPlasmid\"],\n",
-        ")\n",
-        "\n",
-        "plasmid = make_extracted_plasmid(\n",
-        "    uri=\"https://example.org/implementation/plasmid_001\",\n",
-        "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_001\",\n",
-        ")\n",
-        "\n",
-        "for obj in [freezer20, shelf20, box20, slot20, plasmid]:\n",
-        "    doc.add(obj)\n",
-        "\n",
-        "add_child(freezer20, shelf20)\n",
-        "add_child(shelf20, box20)\n",
-        "add_child(box20, slot20)\n",
-        "place_item(slot20, plasmid)\n",
-        "\n",
-        "validate_item(plasmid)\n",
-        "validate_placement(plasmid, slot20)\n",
-        "\n",
-        "print(\"Plasmid stored at:\", plasmid.stored_at)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 3: create a 4 \u00b0C hierarchy and place a solid media plate"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "fridge4 = make_fridge_4c(\"https://example.org/storage/4c\")\n",
-        "shelf4 = make_shelf(\"https://example.org/storage/4c/shelf1\", label=\"Shelf 1\")\n",
-        "box4 = make_box(\"https://example.org/storage/4c/shelf1/rack1\", label=\"Rack 1\")\n",
-        "slot4 = make_slot(\n",
-        "    \"https://example.org/storage/4c/shelf1/rack1/P1\",\n",
-        "    label=\"P1\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#SolidMediaPlate\"],\n",
-        ")\n",
-        "\n",
-        "plate = make_solid_media_plate(\n",
-        "    uri=\"https://example.org/implementation/plate_001\",\n",
-        "    plate_md_uri=\"https://example.org/designs/plate_md_001\",\n",
-        ")\n",
-        "\n",
-        "for obj in [fridge4, shelf4, box4, slot4, plate]:\n",
-        "    doc.add(obj)\n",
-        "\n",
-        "add_child(fridge4, shelf4)\n",
-        "add_child(shelf4, box4)\n",
-        "add_child(box4, slot4)\n",
-        "place_item(slot4, plate)\n",
-        "\n",
-        "validate_item(plate)\n",
-        "validate_placement(plate, slot4)\n",
-        "\n",
-        "print(\"Plate stored at:\", plate.stored_at)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 4: show a validation failure"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "wrong_slot = make_slot(\n",
-        "    \"https://example.org/storage/-80/shelf9/box9/Z9\",\n",
-        "    label=\"Z9\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#BacterialStock\"],\n",
-        ")\n",
-        "\n",
-        "wrong_item = make_extracted_plasmid(\n",
-        "    uri=\"https://example.org/implementation/plasmid_bad\",\n",
-        "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_bad\",\n",
-        ")\n",
-        "\n",
-        "try:\n",
-        "    validate_placement(wrong_item, wrong_slot)\n",
-        "except ValueError as e:\n",
-        "    print(\"Validation error:\", e)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 5: serialize the document"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Uncomment to write RDF/XML once sbol2 is installed and configured:\n",
-        "# from sbol_inventory import write_rdfxml\n",
-        "# write_rdfxml(doc, \"inventory_example.xml\")\n",
-        "# print(\"Wrote inventory_example.xml\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SBOLInventory examples\n",
+    "\n",
+    "This notebook demonstrates how to use **SBOLInventory** to build a storage hierarchy, create inventory implementations, place them into slots, validate placements, and assemble an SBOL document."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sbol2 as sbol\n",
+    "\n",
+    "from sbol_inventory import (\n",
+    "    make_document,\n",
+    "    add_all,\n",
+    "    make_fridge_minus80,\n",
+    "    make_fridge_minus20,\n",
+    "    make_fridge_4c,\n",
+    "    make_shelf,\n",
+    "    make_box,\n",
+    "    make_slot,\n",
+    "    make_bacterial_stock,\n",
+    "    make_extracted_plasmid,\n",
+    "    make_solid_media_plate,\n",
+    "    add_child,\n",
+    "    place_item,\n",
+    "    validate_item,\n",
+    "    validate_placement,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: create a -80 \u00b0C hierarchy and place a bacterial stock"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = make_document()\n",
+    "\n",
+    "freezer = make_fridge_minus80(\"https://example.org/storage/-80\")\n",
+    "shelf = make_shelf(\"https://example.org/storage/-80/shelf2\", label=\"Shelf 2\")\n",
+    "box = make_box(\"https://example.org/storage/-80/shelf2/box4\", label=\"Box 4\")\n",
+    "slot = make_slot(\"https://example.org/storage/-80/shelf2/box4/A4\", label=\"A4\")\n",
+    "\n",
+    "stock = make_bacterial_stock(\n",
+    "    uri=\"https://example.org/implementation/bstock_001\",\n",
+    "    strain_md_uri=\"https://example.org/designs/strain_md_001\",\n",
+    ")\n",
+    "\n",
+    "add_all(doc, [freezer, shelf, box, slot, stock])\n",
+    "add_child(freezer, shelf)\n",
+    "add_child(shelf, box)\n",
+    "add_child(box, slot)\n",
+    "place_item(slot, stock)\n",
+    "\n",
+    "validate_item(stock)\n",
+    "validate_placement(stock, slot)\n",
+    "\n",
+    "print(\"Stored at:\", stock.stored_at)\n",
+    "print(\"Slot members:\", list(slot.members))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: create a -20 \u00b0C hierarchy and place an extracted plasmid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freezer20 = make_fridge_minus20(\"https://example.org/storage/-20\")\n",
+    "shelf20 = make_shelf(\"https://example.org/storage/-20/shelf1\", label=\"Shelf 1\")\n",
+    "box20 = make_box(\"https://example.org/storage/-20/shelf1/box2\", label=\"Box 2\")\n",
+    "slot20 = make_slot(\n",
+    "    \"https://example.org/storage/-20/shelf1/box2/B3\",\n",
+    "    label=\"B3\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#ExtractedPlasmid\"],\n",
+    ")\n",
+    "\n",
+    "plasmid = make_extracted_plasmid(\n",
+    "    uri=\"https://example.org/implementation/plasmid_001\",\n",
+    "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_001\",\n",
+    ")\n",
+    "\n",
+    "for obj in [freezer20, shelf20, box20, slot20, plasmid]:\n",
+    "    doc.add(obj)\n",
+    "\n",
+    "add_child(freezer20, shelf20)\n",
+    "add_child(shelf20, box20)\n",
+    "add_child(box20, slot20)\n",
+    "place_item(slot20, plasmid)\n",
+    "\n",
+    "validate_item(plasmid)\n",
+    "validate_placement(plasmid, slot20)\n",
+    "\n",
+    "print(\"Plasmid stored at:\", plasmid.stored_at)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: create a 4 \u00b0C hierarchy and place a solid media plate\n",
+    "\n",
+    "`SolidMediaPlate` is created as an `InventoryImplementation` (physical item),\n",
+    "then placed into a `Slot` storage collection.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fridge4 = make_fridge_4c(\"https://example.org/storage/4c\")\n",
+    "shelf4 = make_shelf(\"https://example.org/storage/4c/shelf1\", label=\"Shelf 1\")\n",
+    "box4 = make_box(\"https://example.org/storage/4c/shelf1/rack1\", label=\"Rack 1\")\n",
+    "slot4 = make_slot(\n",
+    "    \"https://example.org/storage/4c/shelf1/rack1/P1\",\n",
+    "    label=\"P1\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#SolidMediaPlate\"],\n",
+    ")\n",
+    "\n",
+    "plate = make_solid_media_plate(\n",
+    "    uri=\"https://example.org/implementation/plate_001\",\n",
+    "    plate_md_uri=\"https://example.org/designs/plate_md_001\",\n",
+    ")\n",
+    "\n",
+    "for obj in [fridge4, shelf4, box4, slot4, plate]:\n",
+    "    doc.add(obj)\n",
+    "\n",
+    "add_child(fridge4, shelf4)\n",
+    "add_child(shelf4, box4)\n",
+    "add_child(box4, slot4)\n",
+    "place_item(slot4, plate)\n",
+    "\n",
+    "validate_item(plate)\n",
+    "validate_placement(plate, slot4)\n",
+    "\n",
+    "print(\"Plate stored at:\", plate.stored_at)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: show a validation failure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrong_slot = make_slot(\n",
+    "    \"https://example.org/storage/-80/shelf9/box9/Z9\",\n",
+    "    label=\"Z9\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#BacterialStock\"],\n",
+    ")\n",
+    "\n",
+    "wrong_item = make_extracted_plasmid(\n",
+    "    uri=\"https://example.org/implementation/plasmid_bad\",\n",
+    "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_bad\",\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    validate_placement(wrong_item, wrong_slot)\n",
+    "except ValueError as e:\n",
+    "    print(\"Validation error:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 5: serialize the document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to write RDF/XML once sbol2 is installed and configured:\n",
+    "# from sbol_inventory import write_rdfxml\n",
+    "# write_rdfxml(doc, \"inventory_example.xml\")\n",
+    "# print(\"Wrote inventory_example.xml\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/product.md
+++ b/product.md
@@ -61,6 +61,9 @@ The package must support creation of typed SBOL implementations for:
 - bacterial stock
 - solid media plate
 
+All three are physical inventory objects and must be represented as
+`InventoryImplementation` (SBOL `Implementation`), not storage collections.
+
 ### FR2: storage hierarchy creation
 The package must support creation of storage nodes for:
 - freezer or fridge
@@ -80,6 +83,9 @@ The package must support application-level validation rules:
 - extracted plasmids go to -20 C
 - bacterial stocks go to -80 C
 - solid media plates go to 4 C storage
+
+Placement is expressed through slot membership, where slots are storage
+collections and inventory items (including plates) are implementations.
 
 ### FR5: examples
 The repository must include examples that are easy for humans and AI coding agents to execute and extend.

--- a/src/sbol_inventory/factories.py
+++ b/src/sbol_inventory/factories.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 from .namespaces import (
     EXTRACTED_PLASMID,
@@ -63,7 +63,7 @@ def make_slot(
     label: Optional[str] = None,
     row: Optional[str] = None,
     column: Optional[str] = None,
-    allowed_item_kinds=None,
+    allowed_item_kinds: Optional[Sequence[str]] = None,
 ) -> StorageCollection:
     x = StorageCollection(uri)
     x.storage_kind = SLOT
@@ -74,7 +74,7 @@ def make_slot(
     if column:
         x.column = column
     if allowed_item_kinds:
-        x.allowed_item_kinds = allowed_item_kinds
+        x.allowed_item_kinds = list(allowed_item_kinds)
     return x
 
 
@@ -118,7 +118,12 @@ def make_solid_media_plate(
     slot_uri: Optional[str] = None,
     design_uri: Optional[str] = None,
 ) -> InventoryImplementation:
-    """Create a solid media plate implementation."""
+    """Create a solid media plate as a physical inventory implementation.
+
+    A plate is represented as an ``InventoryImplementation`` (not a storage
+    ``Collection``). It may reference a design object through ``built`` and can
+    be placed into a storage slot like other inventory items.
+    """
     x = InventoryImplementation(uri)
     x.inventory_kind = SOLID_MEDIA_PLATE
     x.built = plate_md_uri
@@ -131,12 +136,18 @@ def make_solid_media_plate(
 
 def add_child(parent: StorageCollection, child) -> None:
     """Attach a storage node or inventory item to a parent collection."""
-    parent.members.add(child.identity)
+    if hasattr(parent.members, "add"):
+        parent.members.add(child.identity)
+    else:
+        parent.members.append(child.identity)
     if isinstance(child, StorageCollection):
         child.parent_storage = parent.identity
 
 
 def place_item(slot: StorageCollection, item: InventoryImplementation) -> None:
     """Place an inventory item into a leaf slot."""
-    slot.members.add(item.identity)
+    if hasattr(slot.members, "add"):
+        slot.members.add(item.identity)
+    else:
+        slot.members.append(item.identity)
     item.stored_at = slot.identity

--- a/src/sbol_inventory/validation.py
+++ b/src/sbol_inventory/validation.py
@@ -21,7 +21,7 @@ def validate_item(item: InventoryImplementation) -> None:
 
 
 def validate_placement(item: InventoryImplementation, slot: StorageCollection) -> None:
-    """Validate whether an item is allowed to be placed in a slot."""
+    """Validate whether an implementation item is allowed in a storage slot."""
     allowed = set(slot.allowed_item_kinds)
     if allowed and str(item.inventory_kind) not in allowed:
         raise ValueError(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,9 +2,13 @@ import pytest
 
 from sbol_inventory import (
     BACTERIAL_STOCK,
+    SOLID_MEDIA_PLATE,
+    InventoryImplementation,
     make_bacterial_stock,
     make_extracted_plasmid,
+    make_solid_media_plate,
     make_slot,
+    place_item,
     validate_item,
     validate_placement,
 )
@@ -41,3 +45,39 @@ def test_validate_placement_rejects_wrong_kind():
     )
     with pytest.raises(ValueError):
         validate_placement(item, slot)
+
+
+def test_make_solid_media_plate_returns_inventory_implementation():
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate1",
+    )
+    assert isinstance(plate, InventoryImplementation)
+    assert str(plate.inventory_kind) == SOLID_MEDIA_PLATE
+
+
+def test_solid_media_plate_can_be_placed_in_slot_when_allowed():
+    slot = make_slot(
+        "https://example.org/storage/4c/shelf1/box1/A1",
+        allowed_item_kinds=[SOLID_MEDIA_PLATE],
+    )
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate1",
+    )
+    validate_placement(plate, slot)
+    place_item(slot, plate)
+    assert str(plate.stored_at) == slot.identity
+
+
+def test_solid_media_plate_placement_rejected_when_slot_disallows_kind():
+    slot = make_slot(
+        "https://example.org/storage/4c/shelf1/box1/A1",
+        allowed_item_kinds=[BACTERIAL_STOCK],
+    )
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate1",
+    )
+    with pytest.raises(ValueError):
+        validate_placement(plate, slot)


### PR DESCRIPTION
### Motivation
- Ensure `SolidMediaPlate` is consistently modeled as a physical inventory item (an SBOL `Implementation`) rather than as a storage `Collection` so it parallels `ExtractedPlasmid` and `BacterialStock`.
- Remove ambiguity in factory/docs/examples and keep storage hierarchy purely `Collection`-based (`FridgeMinus80C`, `FridgeMinus20C`, `Fridge4C`, `Shelf`, `Box`, `Slot`).
- Fix runtime placement robustness where pySBOL2 `members` containers could be list-like or set-like so placement helpers work reliably.

### Description
- Made `make_solid_media_plate(...)` explicitly return an `InventoryImplementation` and added a clarifying docstring explaining that a plate is not a storage node and may reference a biological design via `built` (`src/sbol_inventory/factories.py`).
- Hardened containment helpers `add_child` and `place_item` to append to `members` whether it behaves like a list or exposes an `add` method, and tightened `make_slot` typing for `allowed_item_kinds` (`src/sbol_inventory/factories.py`).
- Updated validation wording to emphasize that implementations are validated against storage slot allowed kinds and preserved the same `validate_item` semantics (`src/sbol_inventory/validation.py`).
- Added tests that assert `make_solid_media_plate(...)` returns an `InventoryImplementation`, that a plate can be placed into an allowed `Slot`, and that placement is rejected when disallowed (`tests/test_validation.py`).
- Updated docs and examples to clearly state that all inventory items (including `SolidMediaPlate`) are `InventoryImplementation` objects and that storage nodes remain `StorageCollection` objects, and updated the notebook narrative to show the correct plate usage (`README.md`, `product.md`, `architechture.md`, `agent.md`, `notebooks/sbol_inventory_examples.ipynb`).
- No breaking public API changes were introduced; helper names and signatures remain stable and the public behavior for `make_solid_media_plate`, `validate_placement`, and `place_item` is preserved.

### Testing
- Ran unit tests with `PYTHONPATH=src pytest -q` and all tests passed (`6 passed`).
- Ran the linter check with `PYTHONPATH=src python -m ruff check src tests` and it passed (`All checks passed`).
- Attempted `pip install -e .` in this environment but build dependency resolution failed due to blocked network/proxy (environmental issue); tests were executed using `PYTHONPATH=src` instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95faeafac8330ace7f47058ba0970)