### PR TITLE
Model SolidMediaPlate consistently as InventoryImplementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Those can be built later on top of this package.
 - `BacterialStock`
 - `SolidMediaPlate`
 
+All three are represented as `InventoryImplementation` (SBOL `Implementation`)
+objects. `SolidMediaPlate` is never modeled as a `Collection`.
+
 ### Storage hierarchy
 - `FridgeMinus80C`
 - `FridgeMinus20C`
@@ -35,6 +38,9 @@ Those can be built later on top of this package.
 - `Shelf`
 - `Box`
 - `Slot`
+
+All storage hierarchy nodes are represented as `StorageCollection` (SBOL
+`Collection`) objects.
 
 ## Repository structure
 
@@ -108,6 +114,42 @@ add_child(box, slot)
 place_item(slot, stock)
 
 validate_placement(stock, slot)
+```
+
+### Solid media plate example (as Implementation)
+
+```python
+from sbol_inventory import (
+    SOLID_MEDIA_PLATE,
+    make_fridge_4c,
+    make_shelf,
+    make_box,
+    make_slot,
+    make_solid_media_plate,
+    add_child,
+    place_item,
+    validate_placement,
+)
+
+fridge4 = make_fridge_4c("https://example.org/storage/4c")
+shelf4 = make_shelf("https://example.org/storage/4c/shelf1", label="Shelf 1")
+box4 = make_box("https://example.org/storage/4c/shelf1/box1", label="Box 1")
+slot4 = make_slot(
+    "https://example.org/storage/4c/shelf1/box1/P1",
+    label="P1",
+    allowed_item_kinds=[SOLID_MEDIA_PLATE],
+)
+
+plate = make_solid_media_plate(
+    uri="https://example.org/implementation/plate_001",
+    plate_md_uri="https://example.org/designs/plate_md_001",
+)
+
+add_child(fridge4, shelf4)
+add_child(shelf4, box4)
+add_child(box4, slot4)
+validate_placement(plate, slot4)
+place_item(slot4, plate)
 ```
 
 ## Design principles

--- a/agent.md
+++ b/agent.md
@@ -69,6 +69,11 @@ At minimum, verify:
 - allowed placement
 - rejected placement
 
+For `SolidMediaPlate`, keep semantics explicit:
+- model it as `InventoryImplementation`
+- place it into slots with `place_item`
+- do not model plates as storage collections
+
 ### 6. Keep notebooks educational
 Notebooks should demonstrate realistic usage patterns, not just toy fragments.
 

--- a/architechture.md
+++ b/architechture.md
@@ -77,6 +77,9 @@ Responsibilities:
 - `notes`
 - `freeze_date`
 
+This includes `SolidMediaPlate`: it is intentionally modeled in parallel with
+`ExtractedPlasmid` and `BacterialStock` as an `InventoryImplementation`.
+
 ### Why extend `Collection`
 The storage system is naturally hierarchical and grouping-oriented. `Collection` is therefore a good fit for representing:
 
@@ -84,6 +87,9 @@ The storage system is naturally hierarchical and grouping-oriented. `Collection`
 - shelves
 - boxes
 - slots
+
+Only storage hierarchy nodes use `StorageCollection`; inventory items (including
+plates) are placed into `Slot` collections via `place_item`.
 
 That keeps the storage layout explicit without inventing a second containment mechanism.
 

--- a/notebooks/sbol_inventory_examples.ipynb
+++ b/notebooks/sbol_inventory_examples.ipynb
@@ -1,222 +1,226 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# SBOLInventory examples\n",
-        "\n",
-        "This notebook demonstrates how to use **SBOLInventory** to build a storage hierarchy, create inventory implementations, place them into slots, validate placements, and assemble an SBOL document."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import sbol2 as sbol\n",
-        "\n",
-        "from sbol_inventory import (\n",
-        "    make_document,\n",
-        "    add_all,\n",
-        "    make_fridge_minus80,\n",
-        "    make_fridge_minus20,\n",
-        "    make_fridge_4c,\n",
-        "    make_shelf,\n",
-        "    make_box,\n",
-        "    make_slot,\n",
-        "    make_bacterial_stock,\n",
-        "    make_extracted_plasmid,\n",
-        "    make_solid_media_plate,\n",
-        "    add_child,\n",
-        "    place_item,\n",
-        "    validate_item,\n",
-        "    validate_placement,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 1: create a -80 \u00b0C hierarchy and place a bacterial stock"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "doc = make_document()\n",
-        "\n",
-        "freezer = make_fridge_minus80(\"https://example.org/storage/-80\")\n",
-        "shelf = make_shelf(\"https://example.org/storage/-80/shelf2\", label=\"Shelf 2\")\n",
-        "box = make_box(\"https://example.org/storage/-80/shelf2/box4\", label=\"Box 4\")\n",
-        "slot = make_slot(\"https://example.org/storage/-80/shelf2/box4/A4\", label=\"A4\")\n",
-        "\n",
-        "stock = make_bacterial_stock(\n",
-        "    uri=\"https://example.org/implementation/bstock_001\",\n",
-        "    strain_md_uri=\"https://example.org/designs/strain_md_001\",\n",
-        ")\n",
-        "\n",
-        "add_all(doc, [freezer, shelf, box, slot, stock])\n",
-        "add_child(freezer, shelf)\n",
-        "add_child(shelf, box)\n",
-        "add_child(box, slot)\n",
-        "place_item(slot, stock)\n",
-        "\n",
-        "validate_item(stock)\n",
-        "validate_placement(stock, slot)\n",
-        "\n",
-        "print(\"Stored at:\", stock.stored_at)\n",
-        "print(\"Slot members:\", list(slot.members))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 2: create a -20 \u00b0C hierarchy and place an extracted plasmid"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "freezer20 = make_fridge_minus20(\"https://example.org/storage/-20\")\n",
-        "shelf20 = make_shelf(\"https://example.org/storage/-20/shelf1\", label=\"Shelf 1\")\n",
-        "box20 = make_box(\"https://example.org/storage/-20/shelf1/box2\", label=\"Box 2\")\n",
-        "slot20 = make_slot(\n",
-        "    \"https://example.org/storage/-20/shelf1/box2/B3\",\n",
-        "    label=\"B3\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#ExtractedPlasmid\"],\n",
-        ")\n",
-        "\n",
-        "plasmid = make_extracted_plasmid(\n",
-        "    uri=\"https://example.org/implementation/plasmid_001\",\n",
-        "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_001\",\n",
-        ")\n",
-        "\n",
-        "for obj in [freezer20, shelf20, box20, slot20, plasmid]:\n",
-        "    doc.add(obj)\n",
-        "\n",
-        "add_child(freezer20, shelf20)\n",
-        "add_child(shelf20, box20)\n",
-        "add_child(box20, slot20)\n",
-        "place_item(slot20, plasmid)\n",
-        "\n",
-        "validate_item(plasmid)\n",
-        "validate_placement(plasmid, slot20)\n",
-        "\n",
-        "print(\"Plasmid stored at:\", plasmid.stored_at)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 3: create a 4 \u00b0C hierarchy and place a solid media plate"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "fridge4 = make_fridge_4c(\"https://example.org/storage/4c\")\n",
-        "shelf4 = make_shelf(\"https://example.org/storage/4c/shelf1\", label=\"Shelf 1\")\n",
-        "box4 = make_box(\"https://example.org/storage/4c/shelf1/rack1\", label=\"Rack 1\")\n",
-        "slot4 = make_slot(\n",
-        "    \"https://example.org/storage/4c/shelf1/rack1/P1\",\n",
-        "    label=\"P1\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#SolidMediaPlate\"],\n",
-        ")\n",
-        "\n",
-        "plate = make_solid_media_plate(\n",
-        "    uri=\"https://example.org/implementation/plate_001\",\n",
-        "    plate_md_uri=\"https://example.org/designs/plate_md_001\",\n",
-        ")\n",
-        "\n",
-        "for obj in [fridge4, shelf4, box4, slot4, plate]:\n",
-        "    doc.add(obj)\n",
-        "\n",
-        "add_child(fridge4, shelf4)\n",
-        "add_child(shelf4, box4)\n",
-        "add_child(box4, slot4)\n",
-        "place_item(slot4, plate)\n",
-        "\n",
-        "validate_item(plate)\n",
-        "validate_placement(plate, slot4)\n",
-        "\n",
-        "print(\"Plate stored at:\", plate.stored_at)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 4: show a validation failure"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "wrong_slot = make_slot(\n",
-        "    \"https://example.org/storage/-80/shelf9/box9/Z9\",\n",
-        "    label=\"Z9\",\n",
-        "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#BacterialStock\"],\n",
-        ")\n",
-        "\n",
-        "wrong_item = make_extracted_plasmid(\n",
-        "    uri=\"https://example.org/implementation/plasmid_bad\",\n",
-        "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_bad\",\n",
-        ")\n",
-        "\n",
-        "try:\n",
-        "    validate_placement(wrong_item, wrong_slot)\n",
-        "except ValueError as e:\n",
-        "    print(\"Validation error:\", e)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Example 5: serialize the document"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Uncomment to write RDF/XML once sbol2 is installed and configured:\n",
-        "# from sbol_inventory import write_rdfxml\n",
-        "# write_rdfxml(doc, \"inventory_example.xml\")\n",
-        "# print(\"Wrote inventory_example.xml\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SBOLInventory examples\n",
+    "\n",
+    "This notebook demonstrates how to use **SBOLInventory** to build a storage hierarchy, create inventory implementations, place them into slots, validate placements, and assemble an SBOL document."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbol_inventory import (\n",
+    "    SOLID_MEDIA_PLATE,\n",
+    "    InventoryImplementation,\n",
+    "    make_document,\n",
+    "    add_all,\n",
+    "    make_fridge_minus80,\n",
+    "    make_fridge_minus20,\n",
+    "    make_fridge_4c,\n",
+    "    make_shelf,\n",
+    "    make_box,\n",
+    "    make_slot,\n",
+    "    make_bacterial_stock,\n",
+    "    make_extracted_plasmid,\n",
+    "    make_solid_media_plate,\n",
+    "    add_child,\n",
+    "    place_item,\n",
+    "    validate_item,\n",
+    "    validate_placement,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: create a -80 \u00b0C hierarchy and place a bacterial stock"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = make_document()\n",
+    "\n",
+    "freezer = make_fridge_minus80(\"https://example.org/storage/-80\")\n",
+    "shelf = make_shelf(\"https://example.org/storage/-80/shelf2\", label=\"Shelf 2\")\n",
+    "box = make_box(\"https://example.org/storage/-80/shelf2/box4\", label=\"Box 4\")\n",
+    "slot = make_slot(\"https://example.org/storage/-80/shelf2/box4/A4\", label=\"A4\")\n",
+    "\n",
+    "stock = make_bacterial_stock(\n",
+    "    uri=\"https://example.org/implementation/bstock_001\",\n",
+    "    strain_md_uri=\"https://example.org/designs/strain_md_001\",\n",
+    ")\n",
+    "\n",
+    "add_all(doc, [freezer, shelf, box, slot, stock])\n",
+    "add_child(freezer, shelf)\n",
+    "add_child(shelf, box)\n",
+    "add_child(box, slot)\n",
+    "place_item(slot, stock)\n",
+    "\n",
+    "validate_item(stock)\n",
+    "validate_placement(stock, slot)\n",
+    "\n",
+    "print(\"Stored at:\", stock.stored_at)\n",
+    "print(\"Slot members:\", list(slot.members))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: create a -20 \u00b0C hierarchy and place an extracted plasmid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freezer20 = make_fridge_minus20(\"https://example.org/storage/-20\")\n",
+    "shelf20 = make_shelf(\"https://example.org/storage/-20/shelf1\", label=\"Shelf 1\")\n",
+    "box20 = make_box(\"https://example.org/storage/-20/shelf1/box2\", label=\"Box 2\")\n",
+    "slot20 = make_slot(\n",
+    "    \"https://example.org/storage/-20/shelf1/box2/B3\",\n",
+    "    label=\"B3\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#ExtractedPlasmid\"],\n",
+    ")\n",
+    "\n",
+    "plasmid = make_extracted_plasmid(\n",
+    "    uri=\"https://example.org/implementation/plasmid_001\",\n",
+    "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_001\",\n",
+    ")\n",
+    "\n",
+    "for obj in [freezer20, shelf20, box20, slot20, plasmid]:\n",
+    "    doc.add(obj)\n",
+    "\n",
+    "add_child(freezer20, shelf20)\n",
+    "add_child(shelf20, box20)\n",
+    "add_child(box20, slot20)\n",
+    "place_item(slot20, plasmid)\n",
+    "\n",
+    "validate_item(plasmid)\n",
+    "validate_placement(plasmid, slot20)\n",
+    "\n",
+    "print(\"Plasmid stored at:\", plasmid.stored_at)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: create a 4 \u00b0C hierarchy and place a solid media plate\n",
+    "\n",
+    "`SolidMediaPlate` is modeled as an `InventoryImplementation` (not as a storage `Collection`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fridge4 = make_fridge_4c(\"https://example.org/storage/4c\")\n",
+    "shelf4 = make_shelf(\"https://example.org/storage/4c/shelf1\", label=\"Shelf 1\")\n",
+    "box4 = make_box(\"https://example.org/storage/4c/shelf1/rack1\", label=\"Rack 1\")\n",
+    "slot4 = make_slot(\n",
+    "    \"https://example.org/storage/4c/shelf1/rack1/P1\",\n",
+    "    label=\"P1\",\n",
+    "    allowed_item_kinds=[SOLID_MEDIA_PLATE],\n",
+    ")\n",
+    "\n",
+    "plate = make_solid_media_plate(\n",
+    "    uri=\"https://example.org/implementation/plate_001\",\n",
+    "    plate_md_uri=\"https://example.org/designs/plate_md_001\",\n",
+    ")\n",
+    "assert isinstance(plate, InventoryImplementation)\n",
+    "\n",
+    "for obj in [fridge4, shelf4, box4, slot4, plate]:\n",
+    "    doc.add(obj)\n",
+    "\n",
+    "add_child(fridge4, shelf4)\n",
+    "add_child(shelf4, box4)\n",
+    "add_child(box4, slot4)\n",
+    "place_item(slot4, plate)\n",
+    "\n",
+    "validate_item(plate)\n",
+    "validate_placement(plate, slot4)\n",
+    "\n",
+    "print(\"Plate kind:\", plate.inventory_kind)\n",
+    "print(\"Plate stored at:\", plate.stored_at)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: show a validation failure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrong_slot = make_slot(\n",
+    "    \"https://example.org/storage/-80/shelf9/box9/Z9\",\n",
+    "    label=\"Z9\",\n",
+    "    allowed_item_kinds=[\"https://draggon.org/ns/inventory#BacterialStock\"],\n",
+    ")\n",
+    "\n",
+    "wrong_item = make_extracted_plasmid(\n",
+    "    uri=\"https://example.org/implementation/plasmid_bad\",\n",
+    "    plasmid_cd_uri=\"https://example.org/designs/plasmid_cd_bad\",\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    validate_placement(wrong_item, wrong_slot)\n",
+    "except ValueError as e:\n",
+    "    print(\"Validation error:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 5: serialize the document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to write RDF/XML once sbol2 is installed and configured:\n",
+    "# from sbol_inventory import write_rdfxml\n",
+    "# write_rdfxml(doc, \"inventory_example.xml\")\n",
+    "# print(\"Wrote inventory_example.xml\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/product.md
+++ b/product.md
@@ -61,6 +61,9 @@ The package must support creation of typed SBOL implementations for:
 - bacterial stock
 - solid media plate
 
+`SolidMediaPlate` is a physical inventory item and must be represented as an
+`InventoryImplementation` (SBOL `Implementation`), not as a storage collection.
+
 ### FR2: storage hierarchy creation
 The package must support creation of storage nodes for:
 - freezer or fridge
@@ -80,6 +83,10 @@ The package must support application-level validation rules:
 - extracted plasmids go to -20 C
 - bacterial stocks go to -80 C
 - solid media plates go to 4 C storage
+
+These rules are enforced through slot placement policies (`allowed_item_kinds`)
+while keeping all storage nodes collection-based (`Fridge`, `Shelf`, `Box`,
+`Slot`).
 
 ### FR5: examples
 The repository must include examples that are easy for humans and AI coding agents to execute and extend.

--- a/src/sbol_inventory/factories.py
+++ b/src/sbol_inventory/factories.py
@@ -118,7 +118,11 @@ def make_solid_media_plate(
     slot_uri: Optional[str] = None,
     design_uri: Optional[str] = None,
 ) -> InventoryImplementation:
-    """Create a solid media plate implementation."""
+    """Create a solid media plate as an inventory implementation.
+
+    Solid media plates are physical tracked items (Implementations), not
+    storage containers. They may reference a biological design via `built`.
+    """
     x = InventoryImplementation(uri)
     x.inventory_kind = SOLID_MEDIA_PLATE
     x.built = plate_md_uri
@@ -129,11 +133,15 @@ def make_solid_media_plate(
     return x
 
 
-def add_child(parent: StorageCollection, child) -> None:
-    """Attach a storage node or inventory item to a parent collection."""
+def add_child(parent: StorageCollection, child: StorageCollection) -> None:
+    """Attach a child storage node to a parent storage collection."""
+    if not isinstance(child, StorageCollection):
+        raise TypeError(
+            "add_child only accepts StorageCollection nodes. "
+            "Use place_item(slot, item) for InventoryImplementation objects."
+        )
     parent.members.add(child.identity)
-    if isinstance(child, StorageCollection):
-        child.parent_storage = parent.identity
+    child.parent_storage = parent.identity
 
 
 def place_item(slot: StorageCollection, item: InventoryImplementation) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,8 +2,11 @@ import pytest
 
 from sbol_inventory import (
     BACTERIAL_STOCK,
+    SOLID_MEDIA_PLATE,
+    InventoryImplementation,
     make_bacterial_stock,
     make_extracted_plasmid,
+    make_solid_media_plate,
     make_slot,
     validate_item,
     validate_placement,
@@ -41,3 +44,37 @@ def test_validate_placement_rejects_wrong_kind():
     )
     with pytest.raises(ValueError):
         validate_placement(item, slot)
+
+
+def test_make_solid_media_plate_returns_inventory_implementation():
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate1",
+        plate_md_uri="https://example.org/designs/plate_md_1",
+    )
+    assert isinstance(plate, InventoryImplementation)
+    assert str(plate.inventory_kind) == SOLID_MEDIA_PLATE
+
+
+def test_validate_placement_accepts_solid_media_plate_when_allowed():
+    slot = make_slot(
+        "https://example.org/storage/4c/shelf1/box1/P1",
+        allowed_item_kinds=[SOLID_MEDIA_PLATE],
+    )
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate2",
+        plate_md_uri="https://example.org/designs/plate_md_2",
+    )
+    validate_placement(plate, slot)
+
+
+def test_validate_placement_rejects_solid_media_plate_when_not_allowed():
+    slot = make_slot(
+        "https://example.org/storage/-80/shelf1/box1/P1",
+        allowed_item_kinds=[BACTERIAL_STOCK],
+    )
+    plate = make_solid_media_plate(
+        uri="https://example.org/implementation/plate3",
+        plate_md_uri="https://example.org/designs/plate_md_3",
+    )
+    with pytest.raises(ValueError):
+        validate_placement(plate, slot)


### PR DESCRIPTION
### Motivation
- Ensure `SolidMediaPlate` is consistently treated as a physical inventory item (an `InventoryImplementation`) rather than a storage `Collection` to keep item vs storage semantics clear. 
- Prevent accidental use of storage containment helpers for inventory items by making the intended API explicit and type-safe. 
- Add regression tests and update docs and examples so the behavior is discoverable and enforced.

### Description
- `make_solid_media_plate` docstring clarified and confirmed to construct an `InventoryImplementation` with `inventory_kind = SOLID_MEDIA_PLATE` in `src/sbol_inventory/factories.py`. 
- `add_child` now only accepts `StorageCollection` children and raises a `TypeError` if passed a non-storage object, and sets `parent_storage` for the child, directing users to `place_item(slot, item)` for inventory items. 
- Tests added to `tests/test_validation.py` to assert `make_solid_media_plate(...)` returns an `InventoryImplementation` and to verify placement acceptance and rejection against `allowed_item_kinds`. 
- Documentation and examples updated (`README.md`, `product.md`, `architechture.md`, `agent.md`, and `notebooks/sbol_inventory_examples.ipynb`) to explicitly state that storage nodes are `StorageCollection` objects and that all tracked physical items (including plates) are `InventoryImplementation` objects placed into `Slot` collections.

### Testing
- Ran `PYTHONPATH=src python -m pytest -q` which resulted in `6 passed` tests. 
- Ran `ruff check .` and the linter passed with no remaining issues.
- New tests validate that `make_solid_media_plate` returns an `InventoryImplementation` and that `validate_placement` accepts or rejects plates according to `Slot.allowed_item_kinds`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95faeafac8330ace7f47058ba0970)